### PR TITLE
Remove redundant product loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
   <!-- Tus scripts modularizados -->
   <script src="notificaciones.js" defer></script>
   <script src="carrito.js" defer></script>
-  <script src="productos.js" defer></script>
 </head>
 <body>
   <nav class="nav">


### PR DESCRIPTION
## Summary
- remove extra `productos.js` script
- load products only through existing `Untitled-1.js`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d3514a798832ebac4e46aac15a708