### PR TITLE
Add dynamic product loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,6 +207,7 @@
   </button>
 
   <script src="Untitled-1.js" defer></script>
+  <script src="loadProducts.js" defer></script>
   
 </body>
 </html>

--- a/loadProducts.js
+++ b/loadProducts.js
@@ -1,0 +1,70 @@
+const SHEET_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRJwvzHZQN3CQarSDqjk_nShegf8F4ydARvkSK55VabxbCi9m8RuGf2Nyy9ScriFRfGdhZd0P54VS5z/pub?output=csv';
+const PLACEHOLDER_IMAGE = 'img/placeholder.png';
+
+function mostrarError(mensaje) {
+  const contenedor = document.getElementById('galeria-productos');
+  if (contenedor) contenedor.innerHTML = `<p class="error">${mensaje}</p>`;
+}
+
+function crearProductoHTML(p) {
+  const agotado = p.stock <= 0;
+  const imagen = p.imagenes.length > 0 ? p.imagenes[0] : PLACEHOLDER_IMAGE;
+  return `
+    <div class="producto-card">
+      <div class="producto-img-container">
+        <img src="${imagen}" alt="${p.nombre}" onerror="this.src='${PLACEHOLDER_IMAGE}'" class="producto-img" loading="lazy">
+      </div>
+      <div class="producto-info">
+        <h3 class="producto-nombre">${p.nombre}</h3>
+        <p class="producto-precio">$U ${p.precio.toLocaleString('es-UY')}</p>
+        <p class="producto-stock">${agotado ? '<span class="texto-agotado">Agotado</span>' : `Stock: ${p.stock}`}</p>
+      </div>
+    </div>`;
+}
+
+function mostrarProductos(productos) {
+  const contenedor = document.getElementById('galeria-productos');
+  if (!contenedor) return;
+  if (!productos || productos.length === 0) {
+    contenedor.innerHTML = '<p>No hay productos para mostrar.</p>';
+    return;
+  }
+  contenedor.innerHTML = productos.map(crearProductoHTML).join('');
+}
+
+function loadProductsFromSheets() {
+  const contenedor = document.getElementById('galeria-productos');
+  if (contenedor) contenedor.innerHTML = '<p>Cargando productos...</p>';
+
+  fetch(SHEET_CSV_URL)
+    .then(r => {
+      if (!r.ok) throw new Error('No se pudo obtener el CSV');
+      return r.text();
+    })
+    .then(csv => {
+      if (typeof Papa === 'undefined') throw new Error('PapaParse no disponible');
+      const { data, errors } = Papa.parse(csv, {
+        header: true,
+        skipEmptyLines: true
+      });
+      if (errors.length) {
+        console.error('Errores al parsear CSV', errors);
+        throw new Error('Error al procesar los datos');
+      }
+      const productos = data.map(row => ({
+        id: parseInt(row.id, 10) || 0,
+        nombre: row.nombre ? row.nombre.trim() : 'Sin nombre',
+        descripcion: row.descripcion ? row.descripcion.trim() : '',
+        precio: parseFloat(row.precio) || 0,
+        stock: parseInt(row.cantidad, 10) || 0,
+        imagenes: row.foto ? row.foto.split(',').map(u => u.trim()).filter(Boolean) : []
+      }));
+      mostrarProductos(productos);
+    })
+    .catch(err => {
+      console.error(err);
+      mostrarError('No se pudieron cargar los productos.');
+    });
+}
+
+document.addEventListener('DOMContentLoaded', loadProductsFromSheets);


### PR DESCRIPTION
## Summary
- add `loadProducts.js` script to fetch Google Sheets CSV with PapaParse
- show placeholder if images are missing and handle errors
- include new script in `index.html`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687d512ebed0832eafc5d0c1f8f78f41