### PR TITLE
Fix Sheets fetch variables

### DIFF
--- a/Untitled-1.js
+++ b/Untitled-1.js
@@ -3,7 +3,7 @@
 // ===============================
 const PRODUCTOS_POR_PAGINA = 6;
 const LS_CARRITO_KEY = 'carrito';
-const SHEET_CSV_URL = window.SHEET_CSV_URL;
+const CSV_URL = window.SHEET_CSV_URL;
 const PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE;
 
 // ===============================
@@ -134,7 +134,7 @@ async function cargarProductosDesdeSheets() {
     if (elementos.galeriaProductos) {
       elementos.galeriaProductos.innerHTML = '<p>Cargando productos...</p>';
     }
-    const resp = await fetch(SHEET_CSV_URL, { headers: { 'Cache-Control': 'no-store' } });
+    const resp = await fetch(CSV_URL, { headers: { 'Cache-Control': 'no-store' } });
     if (!resp.ok) throw new Error('Error al cargar productos.');
     const csvText = await resp.text();
     if (typeof Papa === 'undefined') throw new Error('Papa Parse no disponible');

--- a/loadProducts.js
+++ b/loadProducts.js
@@ -1,5 +1,5 @@
 (function () {
-  const SHEET_CSV_URL = window.SHEET_CSV_URL;
+  const CSV_URL = window.SHEET_CSV_URL;
   const PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE;
 
   function mostrarError(mensaje) {
@@ -35,10 +35,12 @@
 
   async function loadProductsFromSheets() {
     const contenedor = document.getElementById('galeria-productos');
-    if (contenedor) contenedor.innerHTML = '<p>Cargando productos...</p>';
+    const loader = document.getElementById('product-loader');
+    if (loader) loader.hidden = false;
+    if (contenedor) contenedor.innerHTML = '';
 
     try {
-      const resp = await fetch(SHEET_CSV_URL, { cache: 'no-cache' });
+      const resp = await fetch(CSV_URL, { cache: 'no-cache' });
       if (!resp.ok) throw new Error('No se pudo obtener el CSV');
       const csv = await resp.text();
 
@@ -67,6 +69,8 @@
     } catch (err) {
       console.error(err);
       mostrarError('No se pudieron cargar los productos.');
+    } finally {
+      if (loader) loader.hidden = true;
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid const collisions by renaming the Sheets URL variable in the JavaScript
- show product loader while fetching data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d572eb54c832e8f4bc01b01495a56