### PR TITLE
Add modern styles and Google Sheets loader

### DIFF
--- a/gsheets-loader.js
+++ b/gsheets-loader.js
@@ -1,0 +1,59 @@
+/**
+ * Carga de productos desde Google Sheets usando PapaParse
+ * y renderiza una galeria simple.
+ */
+
+const CSV_URL = window.SHEET_CSV_URL;
+const PLACEHOLDER_IMAGE = window.PLACEHOLDER_IMAGE || 'img/placeholder.png';
+
+async function fetchCSV(url) {
+  const resp = await fetch(url, { cache: 'no-cache' });
+  if (!resp.ok) throw new Error('No se pudo obtener el CSV');
+  return resp.text();
+}
+
+function parseProducts(csvText) {
+  if (typeof Papa === 'undefined') throw new Error('PapaParse no disponible');
+  const { data, errors } = Papa.parse(csvText, { header: true, skipEmptyLines: true });
+  if (errors.length) throw new Error('Error al procesar los datos');
+  return data.map(row => ({
+    id: Number(row.id) || 0,
+    nombre: row.nombre || 'Sin nombre',
+    descripcion: row.descripcion || '',
+    precio: Number(row.precio) || 0,
+    stock: Number(row.cantidad) || 0,
+    imagen: row.foto ? row.foto.split(',')[0].trim() : PLACEHOLDER_IMAGE
+  }));
+}
+
+function renderProducts(lista) {
+  const cont = document.getElementById('galeria-productos');
+  if (!cont) return;
+  if (!lista || lista.length === 0) {
+    cont.innerHTML = '<p>No hay productos para mostrar.</p>';
+    return;
+  }
+  cont.innerHTML = lista.map(p => `
+    <div class="producto-card">
+      <img src="${p.imagen}" alt="${p.nombre}" class="producto-img" onerror="this.src='${PLACEHOLDER_IMAGE}'">
+      <h3 class="producto-nombre">${p.nombre}</h3>
+      <p class="producto-precio">$U ${p.precio.toLocaleString('es-UY')}</p>
+      <p class="producto-stock">${p.stock > 0 ? 'Stock: ' + p.stock : '<span class="texto-agotado">Agotado</span>'}</p>
+      <button class="boton-agregar" ${p.stock <= 0 ? 'disabled' : ''}>Agregar al carrito</button>
+    </div>
+  `).join('');
+}
+
+async function cargarProductos() {
+  try {
+    const csv = await fetchCSV(CSV_URL);
+    const productos = parseProducts(csv);
+    renderProducts(productos);
+  } catch (err) {
+    console.error(err);
+    const cont = document.getElementById('galeria-productos');
+    if (cont) cont.innerHTML = '<p class="error">No se pudieron cargar los productos.</p>';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', cargarProductos);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,132 @@
+/* Patofelting Modern Styles */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  --primary-color: #4CAF50;
+  --secondary-color: #8BC34A;
+  --accent-color: #2E7D32;
+  --highlight-color: #e8f5e9;
+  --text-color: #333;
+  --background-color: #fff;
+  --light-gray: #f5f5f5;
+  --medium-gray: #e0e0e0;
+  --dark-gray: #555;
+  --border-radius: 8px;
+  --box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  --transition: 0.3s ease;
+}
+
+*{
+  margin:0;
+  padding:0;
+  box-sizing:border-box;
+}
+
+body{
+  font-family:'Inter','Segoe UI',Tahoma,Geneva,Verdana,sans-serif;
+  color:var(--text-color);
+  background:var(--background-color);
+  line-height:1.6;
+}
+
+img{max-width:100%;height:auto;}
+
+.container{
+  width:100%;
+  max-width:1280px;
+  margin:0 auto;
+  padding:0 20px;
+}
+
+.seccion{padding:100px 0;}
+
+/* Navigation */
+.nav{position:fixed;top:0;width:100%;background:var(--background-color);box-shadow:0 2px 10px rgba(0,0,0,0.1);z-index:1000;}
+.nav-container{display:flex;justify-content:space-between;align-items:center;padding:15px 20px;}
+.menu{display:flex;list-style:none;gap:20px;}
+.menu li a{padding:5px 10px;transition:var(--transition);font-weight:500;border-radius:4px;}
+.menu li a:hover,.menu li a.active{background:var(--highlight-color);color:var(--primary-color);font-weight:600;}
+.hamburguesa{display:none;font-size:1.5rem;background:none;color:var(--text-color);}
+
+/* Hero */
+.hero{position:relative;height:100vh;min-height:600px;margin-top:80px;display:flex;align-items:center;justify-content:center;overflow:hidden;}
+.video-fondo,.video-fallback{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;z-index:-1;}
+.hero-content{text-align:center;color:#fff;z-index:1;padding:20px;max-width:800px;margin:0 auto;}
+.hero-title{font-size:3rem;margin-bottom:10px;}
+.hero-subtitle{font-size:1.75rem;margin-bottom:20px;}
+.hero-description{font-size:1rem;margin-bottom:30px;}
+.cta-container{display:flex;justify-content:center;gap:15px;margin-top:30px;}
+.cta-button{padding:12px 25px;border-radius:var(--border-radius);font-weight:600;transition:var(--transition);background:var(--primary-color);color:#fff;}
+.cta-button.secondary{background:transparent;border:2px solid #fff;}
+.cta-button:hover{transform:translateY(-3px);box-shadow:var(--box-shadow);}
+
+/* Products */
+.productos h2{text-align:center;font-size:2.5rem;margin-bottom:40px;color:var(--primary-color);}
+.galeria-productos{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:25px;margin-top:30px;}
+.producto-card{background:#fff;border-radius:var(--border-radius);overflow:hidden;box-shadow:var(--box-shadow);transition:var(--transition);display:flex;flex-direction:column;}
+.producto-card:hover{transform:translateY(-5px);box-shadow:0 10px 20px rgba(0,0,0,0.1);}
+.producto-img{width:100%;height:250px;object-fit:cover;}
+.producto-nombre{font-size:1.2rem;margin:10px 15px 5px;}
+.producto-precio{font-weight:700;color:var(--primary-color);margin:0 15px 10px;}
+.producto-stock{font-size:0.9rem;margin:0 15px 15px;}
+.texto-agotado{color:var(--error-color);}
+.card-acciones{padding:0 15px 15px;display:flex;gap:10px;}
+.cantidad-input{width:60px;padding:8px;border:1px solid var(--medium-gray);border-radius:var(--border-radius);text-align:center;}
+.boton-agregar{flex:1;padding:8px 15px;background:var(--primary-color);color:#fff;border-radius:var(--border-radius);transition:var(--transition);display:flex;align-items:center;justify-content:center;gap:5px;}
+.boton-agregar:hover{background:var(--accent-color);transform:translateY(-2px);}
+.boton-agregar.agotado{background:var(--medium-gray);cursor:not-allowed;}
+.boton-detalles{margin:0 15px 15px;padding:8px 15px;background:var(--light-gray);color:var(--text-color);border-radius:var(--border-radius);transition:var(--transition);text-align:center;}
+.boton-detalles:hover{background:var(--medium-gray);}
+
+/* Cart */
+.carrito-panel{position:fixed;top:0;right:-100%;width:450px;height:100%;background:#fff;box-shadow:-2px 0 10px rgba(0,0,0,0.1);display:flex;flex-direction:column;z-index:1500;transition:right 0.4s ease;}
+.carrito-panel.active{right:0;}
+.carrito-header,.carrito-footer{background:var(--light-gray);padding:24px;}
+.lista-carrito{flex:1;padding:24px;overflow-y:auto;}
+.carrito-footer p{font-size:1.25rem;font-weight:600;margin-bottom:10px;}
+.carrito-item-subtotal{font-size:1.1rem;color:var(--primary-color);}
+.boton-vaciar-carrito,.boton-finalizar-compra{padding:12px;border-radius:var(--border-radius);transition:var(--transition);}
+.boton-vaciar-carrito:hover,.boton-finalizar-compra:hover{background:var(--accent-color);color:#fff;transform:translateY(-2px);}
+.cerrar-carrito{background:none;border:none;font-size:1.5rem;cursor:pointer;transition:transform var(--transition);}
+.cerrar-carrito:hover{transform:rotate(90deg);}
+.carrito-item-controls button{width:32px;height:32px;border-radius:50%;background:var(--light-gray);border:none;transition:var(--transition);}
+.carrito-item-controls button:hover{background:var(--primary-color);color:#fff;}
+.eliminar-item:hover{transform:scale(1.1);} 
+.carrito-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);opacity:0;visibility:hidden;transition:var(--transition);z-index:1400;}
+.carrito-overlay.active{opacity:1;visibility:visible;}
+
+/* FAQ */
+.faq{background:var(--light-gray);}
+.faq h2{text-align:center;font-size:2.5rem;letter-spacing:-0.02em;margin-bottom:40px;color:var(--primary-color);}
+.faq-item{background:#fff;border-radius:var(--border-radius);box-shadow:var(--box-shadow);margin-bottom:20px;overflow:hidden;transition:box-shadow var(--transition);}
+.faq-item:hover{box-shadow:0 6px 12px rgba(0,0,0,0.1);}
+.faq-toggle{width:100%;padding:20px;text-align:left;font-size:1.1rem;font-weight:600;background:none;border:none;display:flex;justify-content:space-between;align-items:center;cursor:pointer;transition:background var(--transition);}
+.faq-toggle::after{content:'+';color:var(--primary-color);font-size:1.5rem;transition:transform var(--transition);}
+.faq-toggle[aria-expanded="true"]::after{content:'-';}
+.faq-toggle:hover{background:var(--highlight-color);}
+.faq-content{padding:0 20px;max-height:0;overflow:hidden;transition:max-height 0.4s ease,padding 0.4s ease;font-size:1rem;}
+.faq-toggle[aria-expanded="true"] + .faq-content{padding:20px;max-height:300px;}
+
+/* Modal */
+#modal-contenido{background:#fff;border-radius:var(--border-radius);padding:32px;max-width:960px;width:90%;max-height:90vh;overflow-y:auto;box-shadow:0 8px 16px rgba(0,0,0,0.2);transition:opacity var(--transition),transform var(--transition);}
+.modal-nombre{font-size:2rem;margin-bottom:10px;color:var(--primary-color);}
+.modal-precio{font-size:1.5rem;font-weight:700;margin-bottom:15px;}
+
+/* Pagination */
+.paginacion{display:flex;justify-content:center;gap:10px;margin-top:40px;}
+.paginacion button{width:44px;height:44px;border-radius:50%;background:var(--medium-gray);border:none;transition:var(--transition);}
+.paginacion button:hover{background:var(--primary-color);color:#fff;}
+.paginacion .pagina-activa{background:var(--primary-color);color:#fff;box-shadow:var(--box-shadow);}
+
+/* Footer & others */
+.footer{background:var(--background-color);padding:40px 20px;text-align:center;margin-top:60px;}
+.footer a{color:var(--primary-color);}
+
+/* Buttons & Inputs */
+button,input,textarea,select{font-family:'Inter','Segoe UI',Tahoma,Geneva,Verdana,sans-serif;}
+button:focus,input:focus,textarea:focus,select:focus{outline:3px solid var(--primary-color);outline-offset:2px;}
+
+/* Responsive */
+@media(max-width:992px){.about-content,.modal-flex{flex-direction:column;}}
+@media(max-width:768px){.hamburguesa{display:block;}.menu{display:none;flex-direction:column;gap:10px;}.carrito-panel{width:90%;}}
+@media(max-width:576px){.hero-title{font-size:2rem;}.cta-button{padding:10px 20px;}}


### PR DESCRIPTION
## Summary
- add a minimal `styles.css` using Inter fonts, responsive containers, cart, FAQ, and modal styling
- include a simple `gsheets-loader.js` for loading products from Google Sheets with PapaParse

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ef43d4780832e99f88c512a3b1ab9